### PR TITLE
Bugfix/libvirt 0.9.0

### DIFF
--- a/Optional_Installs.md
+++ b/Optional_Installs.md
@@ -47,7 +47,7 @@ I'm using [GitHub](https://github.com/) for my source control with SSH key pair 
 
   * Key Type: Authentication
 
-  * Key: <YOUR-KEY-HERE>
+  * Key: <YOUR-KEY-HERE\>
 
 * Clone down the GitHub repo `(or fork the repo to your own GitHub space if you want to do you own testing)` 
 

--- a/Optional_Installs.md
+++ b/Optional_Installs.md
@@ -75,7 +75,7 @@ git clone https://github.com/naturalblaze/lab-setup-ubuntu-kvm.git
 
 ## VSCode Setup
 
-I'm using VSCode to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote * SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal. This of course optional as you could remote in with any terminal program that you are more comfortable with.
+I'm using VSCode to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote - SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal. This of course optional as you could remote in with any terminal program that you are more comfortable with.
 
 * Install VSCode on the device you want to connect from: [Download](https://code.visualstudio.com/Download)
 

--- a/Optional_Installs.md
+++ b/Optional_Installs.md
@@ -1,18 +1,30 @@
 # Optional Installs
 
-## Description
-
 This module will document some of the optional components I have installed. These components are not required for the automation to run but can be useful.
 
 ## Table of Contents
 
-- [Cockpit](#cockpit-setup)
-- [GitHub](#github-setup)
-- [VSCode](#vscode-setup)
-- [Ansible](#ansible-setup)
+* [Optional Technologies Used](#optional-technologies-used)
 
+* [Cockpit](#cockpit-setup)
 
-### Cockpit Setup
+* [GitHub](#github-setup)
+
+* [VSCode](#vscode-setup)
+
+* [Ansible](#ansible-setup)
+
+## Optional Technologies Used
+
+* [Cockpit](https://cockpit-project.org/)
+
+* [GitHub](https://github.com/)
+
+* [VSCode](https://code.visualstudio.com/)
+
+* [Ansible](https://docs.ansible.com/)
+
+## Cockpit Setup
 
 I'm using [Cockpit](https://cockpit-project.org/) for a graphical WebUI which is free and easy to setup. We will be using IaC tools to automate the deployment of our virtual environments, but it is nice to have a graphical interface to view the resources and their configurations or connect to the consoles in case you have any issues or for troubleshooting.
 
@@ -33,41 +45,47 @@ sudo reboot now
 https://<server-hostname or ip-address>:9090/system
 ```
 
+## GitHub Setup
 
-### GitHub Setup
+> :bulb: **Note:** This requires you already have a GitHub account.
 
-> :exclamation: **Note:** This requires you already have a GitHub account.
-
-I'm using the SSH key pair we created in the [Server_Setup - SSH Key Setup](./Server_Setup.md.md#SSH-Key-Setup) for authentication into GitHub to be able to pull code down from GitHub repositories. This of course optional as you could authenticate with HTTPS as well.
-
+I'm using the SSH key pair we created in the [Server_Setup * SSH Key Setup](#ssh-key-setup) for authentication into GitHub to be able to pull and push code from GitHub repositories. This of course optional as you could authenticate with HTTPS as well.
 
 [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
 
-- Setup SSH key: https://github.com/settings/ssh/new
-    - Title: Ubuntu Lab SSH key
-    - Key Type: Authentication
-    - Key: 
+* Setup SSH key: https://github.com/settings/ssh/new
+
+  * Title: Ubuntu Lab SSH key
+
+  * Key Type: Authentication
+
+  * Key: <YOUR-KEY-HERE>
+
+* Create a local directory and clone down the GitHub repo
 
 ```bash
-mkdir ~/tf-workspaces
-cd ~/tf-workspaces
 git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
 ```
 
+* No SSH key setup pull from public repos
 
-### VSCode Setup
+```bash
+git clone https://github.com/naturalblaze/lab-setup-ubuntu-kvm.git
+```
 
-I'm using VSCode to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote - SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal. This of course optional as you could remote in with any terminal program that you are more comfortable with.
+## VSCode Setup
 
-- Install VSCode on the device you want to connect from: [Download](https://code.visualstudio.com/Download)
+I'm using VSCode to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote * SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal. This of course optional as you could remote in with any terminal program that you are more comfortable with.
 
-- Copy the text from the SSH Private key on the lab server
+* Install VSCode on the device you want to connect from: [Download](https://code.visualstudio.com/Download)
+
+* Copy the text from the SSH Private key on the lab server
 
 ```bash
 cat ~/.ssh/id_ed25519
 ```
 
-- Create the SSH Private key file from the system you are trying to connect from
+* Create the SSH Private key file from the system you are trying to connect from
 
 > :exclamation: **Note:** My personal laptop is running Linux PopOS so the path to the SSH Private key is the same as on the lab server.  If you are connecting from a Windows devices your path would be something like `C:\Users\<username>\.ssh`
 
@@ -78,90 +96,88 @@ cat > ~/.ssh/id_ed25519 << EOF
 EOF
 ```
 
-- Open VSCode and download the `Remote - SSH` extension
+* Open VSCode and download the `Remote * SSH` extension
 
-  - Extensions button on left bar
+  * Extensions button on left bar
 
-  - Search for `Remote - SSH` and Install
+  * Search for `Remote * SSH` and Install
 
-- Configure SSH Hosts in VSCode
+* Configure SSH Hosts in VSCode
 
-  - Select `><`  button in bottom left corner
+  * Select `><`  button in bottom left corner
 
-  - Connect to Host
+  * Connect to Host
 
-  - Configure SSH Hosts
+  * Configure SSH Hosts
 
-  - Select the path to SSH config file for your system
+  * Select the path to SSH config file for your system
 
-  - Add the below code to your config file
+  * Add the below code to your config file
 
-  ```bash
-  Host <lab server name>
-    HostName <lab server name or ip address>
-    User <lab username>
-    IdentityFile <path to id_ed25519>
-  ```
+```bash
+Host <lab server name>
+HostName <lab server name or ip address>
+User <lab username>
+IdentityFile <path to id_ed25519>
+```
 
+## Ansible Setup
 
-### Ansible Setup
-
-Ansible is a very powerful open-source agentless automation tool. You could in fact do all these same KVM deployments just using Ansible. I am mainly going to use it for installing software and configurations during our deployments as I find it easier to deploy these things via Ansible than through Terraform. 
+Ansible is a very powerful open-source agentless automation tool. You could in fact do all these same KVM deployments just using Ansible. I am mainly going to use it for installing software and configurations during our deployments as I find it easier to deploy these things via Ansible than through Terraform.
 
 [Ansible Docs](https://docs.ansible.com/)
 
-- Update your system
+* Update your system
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 ```
 
-- Install software properties common
+* Install software properties common
 
 ```bash
 sudo apt install software-properties-common -y
 ```
 
-- Add Ansible Official PPA
+* Add Ansible Official PPA
 
 ```bash
 sudo add-apt-repository --yes --update ppa:ansible/ansible
 ```
 
-- Install Ansible
+* Install Ansible
 
 ```bash
 sudo apt update && sudo apt-get -y install ansible
 ```
 
-- Validate Ansible is installed
+* Validate Ansible is installed
 
 ```bash
 ansible --version
 ```
 
+### [Next Project - Deploy Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md)
 
-### [Next Lesson - Deploy Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md)
-
------
+---
 
 ### Resources
 
 #### Repo Table of Contents:
 
-- [Home](./README.md)
+* [Home](./README.md)
 
-- [Server Setup](./Server_Setup.md)
+* [Server Setup](./Server_Setup.md)
 
-- [Optional Installs](./Optional_Installs.md)
+* [Optional Installs](./Optional_Installs.md)
 
-- Terraform Deployments:
+* Terraform Deployments:
 
-    - [Ubuntu VM](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+    * [Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy an Ubuntu Linux Server VM.
 
-    - [Ubuntu VM K8S Single Node with MicroK8S](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy a simple Ubuntu Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+    * [Ubuntu VM K8S Single Node MicroK8S with Terraform](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy an Ubuntu Linux Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
 
------
+---
 
 #### GitHub Repo Information:
 
@@ -169,4 +185,4 @@ GitHub Repository: [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-se
 
 Author: Blaze Bryant [naturalblaze](https://github.com/naturalblaze)
 
------
+---

--- a/Optional_Installs.md
+++ b/Optional_Installs.md
@@ -4,8 +4,6 @@ This module will document some of the optional components I have installed. Thes
 
 ## Table of Contents
 
-* [Optional Technologies Used](#optional-technologies-used)
-
 * [Cockpit](#cockpit-setup)
 
 * [GitHub](#github-setup)
@@ -13,16 +11,6 @@ This module will document some of the optional components I have installed. Thes
 * [VSCode](#vscode-setup)
 
 * [Ansible](#ansible-setup)
-
-## Optional Technologies Used
-
-* [Cockpit](https://cockpit-project.org/)
-
-* [GitHub](https://github.com/)
-
-* [VSCode](https://code.visualstudio.com/)
-
-* [Ansible](https://docs.ansible.com/)
 
 ## Cockpit Setup
 
@@ -49,7 +37,7 @@ https://<server-hostname or ip-address>:9090/system
 
 > :bulb: **Note:** This requires you already have a GitHub account.
 
-I'm using the SSH key pair we created in the [Server_Setup * SSH Key Setup](#ssh-key-setup) for authentication into GitHub to be able to pull and push code from GitHub repositories. This of course optional as you could authenticate with HTTPS as well.
+I'm using [GitHub](https://github.com/) for my source control with SSH key pair authentication. We will use the SSH key pair created in the [Server_Setup - SSH Key Setup](./Server_Setup.md#ssh-key-setup) for authentication into GitHub to be able to pull and push code from GitHub repositories. This of course optional as you could authenticate with HTTPS as well.
 
 [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
 
@@ -61,7 +49,7 @@ I'm using the SSH key pair we created in the [Server_Setup * SSH Key Setup](#ssh
 
   * Key: <YOUR-KEY-HERE>
 
-* Create a local directory and clone down the GitHub repo
+* Clone down the GitHub repo `(or fork the repo to your own GitHub space if you want to do you own testing)` 
 
 ```bash
 git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
@@ -75,11 +63,11 @@ git clone https://github.com/naturalblaze/lab-setup-ubuntu-kvm.git
 
 ## VSCode Setup
 
-I'm using VSCode to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote - SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal. This of course optional as you could remote in with any terminal program that you are more comfortable with.
+I'm using [VSCode](https://code.visualstudio.com/) to connect to the lab server. It is a cross-platform editor with a extensive sweet of extensions. VSCode has a extension for `Remote - SSH` that lets you easily connect to a remote Linux server and edit code files and access the servers terminal.
 
 * Install VSCode on the device you want to connect from: [Download](https://code.visualstudio.com/Download)
 
-* Copy the text from the SSH Private key on the lab server
+* Copy the text from the SSH Private key on the **lab server**
 
 ```bash
 cat ~/.ssh/id_ed25519
@@ -87,7 +75,7 @@ cat ~/.ssh/id_ed25519
 
 * Create the SSH Private key file from the system you are trying to connect from
 
-> :exclamation: **Note:** My personal laptop is running Linux PopOS so the path to the SSH Private key is the same as on the lab server.  If you are connecting from a Windows devices your path would be something like `C:\Users\<username>\.ssh`
+> :bulb: **Note:** My personal laptop is running Linux PopOS so the path to the SSH Private key is the same as on the lab server.  If you are connecting from a Windows devices your path would be something like `C:\Users\<username>\.ssh`
 
 ```bash
 # Create file SSH Private key
@@ -96,11 +84,11 @@ cat > ~/.ssh/id_ed25519 << EOF
 EOF
 ```
 
-* Open VSCode and download the `Remote * SSH` extension
+* Open VSCode and download the `Remote - SSH` extension
 
   * Extensions button on left bar
 
-  * Search for `Remote * SSH` and Install
+  * Search for `Remote - SSH` and Install
 
 * Configure SSH Hosts in VSCode
 
@@ -114,16 +102,16 @@ EOF
 
   * Add the below code to your config file
 
-```bash
+```text
 Host <lab server name>
-HostName <lab server name or ip address>
-User <lab username>
-IdentityFile <path to id_ed25519>
+  HostName <lab server name or ip address>
+  User <lab username>
+  IdentityFile <path to id_ed25519>
 ```
 
 ## Ansible Setup
 
-Ansible is a very powerful open-source agentless automation tool. You could in fact do all these same KVM deployments just using Ansible. I am mainly going to use it for installing software and configurations during our deployments as I find it easier to deploy these things via Ansible than through Terraform.
+[Ansible](https://docs.ansible.com/) is a very powerful open-source agentless automation tool. You could in fact do all these same KVM deployments just using Ansible. I am mainly going to use it for installing software and configurations during our deployments as it is easier to deploy and validate these things via Ansible rather than through Terraform.
 
 [Ansible Docs](https://docs.ansible.com/)
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ lab-setup-ubuntu-kvm/
     │   │   ├── cloud_init.tftpl
     │   │   ├── meta_data.tftpl
     │   │   └── network_config.tftpl
-    │   ├── terraform.tfstate
-    │   ├── terraform.tfstate.backup
-    │   ├── terraform.tfvars
     │   ├── terraform.tfvars.example
     │   ├── Ubuntu_VM.md
     │   └── variables.tf
@@ -71,9 +68,6 @@ lab-setup-ubuntu-kvm/
         │   ├── cloud_init.tftpl
         │   ├── meta_data.tftpl
         │   └── network_config.tftpl
-        ├── terraform.tfstate
-        ├── terraform.tfstate.backup
-        ├── terraform.tfvars
         ├── terraform.tfvars.example
         ├── Ubuntu_VM_MicroK8S.md
         └── variables.tf

--- a/README.md
+++ b/README.md
@@ -43,25 +43,30 @@ lab-setup-ubuntu-kvm/
 └── tf-workspaces
     ├── ubuntu_vm
     │   ├── data.tf
+    │   ├── main.tf
     │   ├── output.tf
     │   ├── provider.tf
-    │   ├── resource.tf
     │   ├── templates
     │   │   ├── cloud_init.tftpl
     │   │   ├── meta_data.tftpl
     │   │   └── network_config.tftpl
+    │   ├── terraform.tfstate
+    │   ├── terraform.tfstate.backup
+    │   ├── terraform.tfvars
     │   ├── terraform.tfvars.example
     │   ├── Ubuntu_VM.md
     │   └── variables.tf
     └── ubuntu_vm_microk8s
         ├── ansible
+        │   ├── inventory.ini
         │   ├── microk8s_install.yaml
         │   ├── nginx_install.yaml
         │   └── ping.yaml
+        ├── ansible.cfg
         ├── data.tf
+        ├── main.tf
         ├── output.tf
         ├── provider.tf
-        ├── resource.tf
         ├── templates
         │   ├── cloud_init.tftpl
         │   ├── meta_data.tftpl

--- a/README.md
+++ b/README.md
@@ -1,38 +1,36 @@
-# Automate your ssh-IT
+# Lab Setup
+
+## Ubuntu Lab Server with KVM, Libvirt, QEMU, Terraform and Ansible
 
 GitHub Repository: [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-setup-ubuntu-kvm)
 
 Author: Blaze Bryant [naturalblaze](https://github.com/naturalblaze)
 
-
 ## Description
 
-I wanted to create a lab environment where I could easily deploy and destroy virtualized technologies using IaC tools for learning, testing, and development purposes. I have an old Intel NUC I used for the base server with Ubuntu 24.04 Server with KVM, QEMU, and Libvirt to support virtualization.
+I wanted to create a lab environment where I could easily deploy and destroy virtualized technologies using IaC tools for learning, testing, and development purposes. I have a MiniPC I used for a headless base server running Ubuntu 24.04 Server with KVM, QEMU, and Libvirt to support virtualization. You could use many different Linux distributions or even desktop flavors, but we are going to focus on Linux.
 
-> :exclamation: **Note:** I'm using Ubuntu 24.04 server image to run as a headless server that I can SSH to via the command-line, but you could also use the Desktop version if your more comfortable with a Graphical interface.
+### [Next Project - Server Setup](./Server_Setup.md)
 
-
-### [Next Lesson - Server Setup](./Server_Setup.md)
-
------
+---
 
 ## Resources
 
 ### Repo Table of Contents:
 
-- [Home](./README.md)
+* [Home](./README.md)
 
-- [Server Setup](./Server_Setup.md)
+* [Server Setup](./Server_Setup.md)
 
-- [Optional Installs](./Optional_Installs.md)
+* [Optional Installs](./Optional_Installs.md)
 
-- Terraform Deployments:
+* Terraform Deployments:
 
-    - [Ubuntu VM](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+    * [Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy an Ubuntu Linux Server VM.
 
-    - [Ubuntu VM K8S Single Node with MicroK8S](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy a simple Ubuntu Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+    * [Ubuntu VM K8S Single Node MicroK8S with Terraform](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy an Ubuntu Linux Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
 
------
+---
 
 ### Repo Structure:
 

--- a/Server_Setup.md
+++ b/Server_Setup.md
@@ -1,95 +1,85 @@
 # Server Setup
 
+This first module will document the setup process I used to build the base server that is used to automate the deployment of virtualized environments that the different technologies can be deployed to.
 
 ## Table of Contents
 
-- [Description](./Server_Setup.md#description)
+* [Server Technologies Used](./Server_Setup.md#server-technologies-used)
 
-- [Technologies Used](./Server_Setup.md#technologies-used)
+* [Physical Linux Server Setup](./Server_Setup.md#physical-linux-server-setup)
 
-- [Deployment Process](./Server_Setup.md#deployment-process)
+* [SSH Key Setup](./Server_Setup.md#ssh-key-setup)
 
-  - [Physical Linux Server Setup](./Server_Setup.md#physical-linux-server-setup)
+* [KVM, QEMU, & Libvirt Setup](./Server_Setup.md#kvm-qemu-and-libvirt-setup)
 
-  - [SSH Key Setup](./Server_Setup.md#ssh-key-setup)
+* [Terraform Installation](./Server_Setup.md#terraform-installation)
 
-  - [KVM, QEMU, & Libvirt Setup](./Server_Setup.md#kvm-qemu-and-libvirt-setup)
+## Server Technologies Used
 
-  - [Terraform Installation](./Server_Setup.md#terraform-installation)
+* [Ubuntu Server 24.04 LTS Server](https://ubuntu.com/blog/tag/ubuntu-24-04-lts)
 
+* [Linux KVM](https://linux-kvm.org/page/Main_Page)
 
-## Description
+* [QEMU](https://www.qemu.org/)
 
-This first module will document the setup process I used to build the base server that is used to automate the deployment of virtualized environments that the different technologies can be deployed to.
+* [Libvirt](https://libvirt.org/apps.html)
 
-> :exclamation: **Note:** I'm using Ubuntu 24.04 server image to run as a headless server that I can SSH to via the command-line, but you could also use the Desktop version if your more comfortable with a Graphical interface.
+* [Terraform](https://www.terraform.io/)
 
+## Physical Linux Server Setup
 
-## Technologies Used
+* Follow the procedures to create the install media and do the physical install Ubuntu Server on your target hardware: [Ubuntu Server Install Guide](https://ubuntu.com/tutorials/install-ubuntu-server#1-overview)
 
-- [Ubuntu Server 24.04 LTS Server](https://ubuntu.com/blog/tag/ubuntu-24-04-lts)
-- [Linux KVM](https://linux-kvm.org/page/Main_Page)
-- [QEMU](https://www.qemu.org/)
-- [Libvirt](https://libvirt.org/apps.html)
-- [Terraform](https://www.terraform.io/)
+> :bulb: **Note:** I prefer to setup a static IP address for my server so I know exactly where my server will always be after reboots but you could also use DHCP reservations on your router if you prefer.
 
+* Login and validate you can access your server remotely
 
-## Deployment Process
-
-### Physical Linux Server Setup
-
-- Follow the procedures to create the install media and do the physical install Ubuntu Server on your target hardware: [Ubuntu Server Install Guide](https://ubuntu.com/tutorials/install-ubuntu-server#1-overview)
-
-- Login and validate you can access your server remotely
-
-- Update your system and packages
+* Update your system and packages
 
 ```bash
 # Update system packages
 sudo apt update && sudo apt -y upgrade
 ```
 
-- Validate your system supports hardware virtualization
+* Validate your system supports hardware virtualization
 
 ```bash
 # Verify Hardware Virtualization Support
 egrep -c '(vmx|svm)' /proc/cpuinfo
 ```
 
-- Install package `cpu-checker` which you can use to validate KVM is supported by your hardware
+* Install package `cpu-checker` which you can use to validate KVM is supported by your hardware
 
 ```bash
 # Install cpu-checker package
 sudo apt -y install cpu-checker
 ```
 
-- Verify KVM can be used
+* Verify KVM can be used
 
 ```bash
 # Verify KVM can be used
 kvm-ok
 ```
 
+> :warning: **Note:** It is critical your system support virtualization and kvm. If either of those checks fail you will want to verify your system supports virtualization and it is enabled. Some systems will have virtualization disabled by default in the bios so you may need to enable it there, but you will have to do some googling based on your hardware setup.
 
 ### SSH Key Setup
 
-Creating SSH keys for your user on your lab server will allow for the automated deployment and configuration of your virtual environments.
+Creating SSH keys for your user on your lab server will allow for the automated deployment and configuration of your virtual environments. It is up to you if you want to password protect your SSH key but since this is a lab setup you can just hit enter twice to bypass the need of a password. If you already have SSH keys generated you can just copy those over to the lab server as well to the `~/.ssh` folder of the users home. Some additional documentation can be found in [GiHub Docs - Generating a new SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 
-- Create an SSH key pair for your local user:
+* Create an SSH key pair for your local user
 
-> :warning: **Note:** The documentation uses the default path and filenames for the SSH public and private keys. You can customize their names and/or locations but make note of paths and names as you would need adjust in the later commands.
+> :exclamation: **Note:** The documentation uses the default path and filenames for the SSH public and private keys. You can customize their names and/or locations but make note of paths and names as you would need adjust in the later commands.
 
 ```bash
 ssh-keygen -t ed25519 -C "<Description of your key pair here>"
     Path: /home/<username>/.ssh/id_ed25519
 ```
 
-- Add ssh public key to authorized keys, to the ssh-agent, and to your profile so they are loaded upon login
+* Load the ssh-agent and add your private key. Add it to your profile so they are loaded upon login
 
 ```bash
-# Add your public key to the authorized keys to allow for password-less login from your local computer, IDE, etc.
-cat ~/.ssh/id_ed25519.pub >> .ssh/authorized_keys
-
 # Add the private key to the ssh-agent
 eval $(ssh-agent)
 ssh-add ~/.ssh/id_ed25519
@@ -103,17 +93,47 @@ ssh-add ~/.ssh/id_ed25519
 EOF
 ```
 
+* Optional: Add your public key to the authorized keys if you want to use the same private key from your local computer, IDE, etc. to connect to the lab. You could also create separate keys for those systems and add them to the lab server with `ssh-copy-id <USER-NAME>@<LAB-IP-ADDRESS>`
+
+```bash
+# Add your public key to the authorized keys to allow for access to the lab system
+cat ~/.ssh/id_ed25519.pub >> .ssh/authorized_keys
+```
+
+* Disable SSH host checking and disable storing server keys
+
+> :stop_sign: **Note: DOING THIS IS A TERRIBLE SECURITY PRACTICE!** I would never recommend doing this but since this is a lab device and we will be creating and destroying VM's most likely with the same server names and IP addresses this will make sure the server keys are not stored when connecting which will cause a connection error if that servers fingerprint changes.
+
+```bash
+cat >> ~/.ssh/config << 'EOF'
+Host *
+        StrictHostKeyChecking no
+        UserKnownHostsFile=/dev/null
+EOF
+```
+
+> Alternatively you can just remove the old host key whenever a host is re-created.
+>
+> ```bash
+> ssh-keygen -f '~/.ssh/known_hosts' -R <server-name or ip-address>
+> ```
+
+* Setup passwordless sudo commands
+
+```bash
+echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER
+```
 
 ### KVM, QEMU, and Libvirt Setup
 
-- Install packages needed for KVM, QEMU, & Libvirt
+* Install packages needed for KVM, QEMU, & Libvirt
 
 ```bash
 # Update Ubuntu and KVM packages
 sudo apt update && sudo apt -y install bridge-utils libvirt-clients libvirt-daemon-system qemu-kvm virtinst guestfs-tools
 ```
 
-- Setup Libvirt and QEMU to run as the local user
+* Setup Libvirt and QEMU to run as the local user
 
 > :exclamation: **Note:** This will help prevent permission issues with files that are created. The `security_drive` definition will prevent AppArmor from blocking libvirt from creating system resources.
 
@@ -129,9 +149,10 @@ user = "<username>"
 group = "kvm"
 security_driver = "none"
 -----
+esc :wq
 ```
 
-- Start and enable auto-start for the `libvirt-damon`
+* Start and enable auto-start for the `libvirt-damon`
 
 ```bash
 # Start libvirt-daemon and enable for autostart
@@ -142,34 +163,35 @@ sudo systemctl start libvirtd
 sudo systemctl status libvirtd
 ```
 
-- Validate the KVM kernel module is loaded
+* Validate the KVM kernel module is loaded
 
 ```bash
 # Validate kernel module
 lsmod |grep "kvm"
 ```
 
-- Add local user account to the kvm and libvirt groups
+* Add local user account to the kvm and libvirt groups
 
-> :warning: Groups will not show in `id` until logout/in or refresh your profile
+> :warning: Groups will not show in `id` until logout/in or refresh your profile `. ~/.profile`
 
 ```bash
 # Add user to kvm/libvirt groups
 sudo usermod -aG kvm,libvirt $USER
+
+# Reload your profile
+. ~/.profile
 ```
 
-> :warning: The `default` KVM network uses a local virtualized subnet via the `virbr0` virtual interface and NAT which allows external internet access. You will not be able to connect to the virtualized systems from outside your lab server using the `default` network. Creating a bridged network will allow the VMs to obtain an IP address on your local LAN.
+> :bulb: **Note:** The `default` KVM network uses a local virtualized subnet via the `virbr0` virtual interface and NAT which allows external internet access. You will not be able to connect to the virtualized systems from outside your lab server using the `default` network. Creating a bridged network will allow the VMs to obtain an IP address on your local LAN. More information can be read at [NetworkConnectionBridge](https://help.ubuntu.com/community/NetworkConnectionBridge).
 
-- Backup the existing network configuration
+* Backup the existing network configuration
 
 ```bash
 # Backup network config interface
 sudo cp /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml-$(date +'%Y-%m-%d').bak
 ```
 
-- Edit the `netplan` network interface YAML file
-
-> :warning: **Note:** The network interface name may be different on your hardware and/or you may have multiple interfaces. I like to create a bridged network interface with a static IP address so I know exactly what IP address the lab server will have during boot which is handy if you are setting up a local DNS server and want to resolve the lab server by the hostname. There are other ways to define the IP address so it is consistent but that all depends on your local network setup.
+* Edit the `netplan` network interface YAML file to create a bridged network interface `br0`. This is also convenient if your system has multiple network interfaces you can combine them into one bridged interface for speed and resiliency. Make sure to change the `<ethernet-interface>`, `<static-ip-address>`, `<cider-subnet>`, `<gateway-ip-address>`, `<dns-nameserver1>`, and `<dns-nameserver2>` fields to reflect your hardware and network settings.
 
 ```bash
 # Create bridge interface
@@ -178,16 +200,16 @@ sudo vi /etc/netplan/50-cloud-init.yaml
 network:
   version: 2
   ethernets:
-    eno1:
+    <ethernet-interface>:
       dhcp4: false
       dhcp6: false
 
   bridges:
     br0:
-      interfaces: [eno1]
+      interfaces: [<ethernet-interface>]
       dhcp4: false
       dhcp6: false
-      addresses: [<static-ip-address>/24]
+      addresses: [<static-ip-address>/<cider-subnet>]
       routes:
         - to: default
           via: <gateway-ip-address>
@@ -199,9 +221,10 @@ network:
         stp: true
         forward-delay: 4
 -----
+esc :wq
 ```
 
-- Test and apply the new network configuration
+* Test and apply the new network configuration
 
 ```bash
 # Test and apply netplan
@@ -213,7 +236,7 @@ ip address
 ip route
 ```
 
-- Create bridged KVM network
+* Create bridged KVM network
 
 ```bash
 # Create file for KVM bridged network
@@ -226,17 +249,15 @@ cat > ~/br0.xml << EOF
 EOF
 
 # Apply the bridged network, start it, and set it to auto-start
-virsh net-define ~/br0.xml
-virsh net-start hostbridge
-virsh net-autostart hostbridge
+sudo virsh net-define ~/br0.xml
+sudo virsh net-start hostbridge
+sudo virsh net-autostart hostbridge
 
 # Validated KVM networks
-virsh net-list --all
+sudo virsh net-list --all
 ```
 
-- Setup folders for storage pools and set permissions to the local user
-
-> :exclamation: **Note:** The default location for libvirt images is `/var/lib/libvirt/images/`. I am creating a directory called `terraform` in this location to hold our `storage_pools` and `vm_domains` but you can name it whatever you want
+* Setup folders for storage pools and set permissions to the local user. The default location for libvirt images is `/var/lib/libvirt/images/`. I am creating a directory called `terraform` in this location to hold our `storage_pools` and `vm_domains` but you can name it whatever you want.
 
 ```bash
 # Create folder to hold the storage pools and vm images
@@ -248,30 +269,40 @@ sudo chown $USER:kvm /var/lib/libvirt/images/terraform
 sudo chmod 775 /var/lib/libvirt/images/terraform
 ```
 
-- Create the a `default` storage pool, start, and set to auto-start on boot
+* Create the a `default` storage pool, start, and set to auto-start on boot
+
+> :bulb: **Note:** You could run these commands without sudo but then the storage pool would be created as a `session` resource instead of a `system` resource. You can read more about the difference between the two resources with Libvirt ([qemu:///system or qemu:///session](https://wiki.libvirt.org/FAQ.html#what-is-the-difference-between-qemu-system-and-qemu-session-which-one-should-i-use)). I'm going to use system so that when we deploy our resources with terraform we won't run into any permisison issues due to possible different users.
 
 ```bash
-# Create default pool
-virsh pool-define-as default dir --target /var/lib/libvirt/images/terraform
-virsh pool-build default
-virsh pool-start default
-virsh pool-autostart default
-virsh pool-info default
+# Create default and pool
+sudo virsh pool-define-as default dir --target /var/lib/libvirt/images
+sudo virsh pool-build default
+sudo virsh pool-start default
+sudo virsh pool-autostart default
+sudo virsh pool-info default
+# Create terraform pool
+sudo virsh pool-define-as terraform dir --target /var/lib/libvirt/images/terraform
+sudo virsh pool-build terraform
+sudo virsh pool-start terraform
+sudo virsh pool-autostart terraform
+sudo virsh pool-info terraform
 
 # Validate KVM pool
-virsh pool-list --all
+sudo virsh pool-list --all
 ```
 
 ### Terraform Installation
 
-- Install Linux packages (`gnupg`, `software-properties-common`, `mkisofs`):
+Terraform is an open-source Infrastructure as Code (IaC) tool that allows users to define and provision infrastructure using a declarative language in configuration files. It enables safe and efficient management of both cloud and on-premises resources, including compute, storage, networking, and high-level components like DNS entries. By writing code to describe the desired state of their infrastructure, users can automate provisioning, manage its lifecycle, and ensure consistency and scalability. I'm going to use it to easily spin up different infrastructure environments for our lab. [Terraform install documentation](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+
+* Install Linux packages (`gnupg`, `software-properties-common`, `mkisofs`):
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y gnupg software-properties-common mkisofs
 ```
 
-- Install the HashiCorp GPG Key:
+* Install the HashiCorp GPG Key:
 
 ```bash
 wget -O- https://apt.releases.hashicorp.com/gpg | \
@@ -279,7 +310,7 @@ gpg --dearmor | \
 sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
 ```
 
-- Verify the key's fingerprint:
+* Verify the key's fingerprint:
 
 ```bash
 gpg --no-default-keyring \
@@ -287,7 +318,7 @@ gpg --no-default-keyring \
 --fingerprint
 ```
 
-- Add official HashiCorp repository
+* Add official HashiCorp repository
 
 ```bash
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
@@ -295,43 +326,56 @@ https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
 sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
-- Download and install the package from HashiCorp
+* Download and install the package from HashiCorp
 
 ```bash
 sudo apt update && sudo apt install -y terraform
 ```
 
-- Verify the install:
+* Verify the install:
 
 ```bash
 terraform -help plan
 ```
 
+* Enable tab completion
+
+```bash
+# Make sure bashrc file exists
+touch ~/.bashrc
+
+# Install terraform autocomplete
+terraform -install-autocomplete
+
+# Restart your shell
+reset; exec bash
+```
 
 ## **🎉 At this point your system is setup and ready to `virtualize` 🎉**
 
+> Check out the [Optional Installs](./Optional_Installs.md) for some additional setups for Cockpit, GitHub, VSCode and Ansible to help with your IaC learning.
 
-### [Next Step - Ubuntu VM](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+### [Next Project - Deploy Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md)
 
------
+---
 
 ### Resources
 
 #### Repo Table of Contents:
 
-- [Home](./README.md)
+* [Home](./README.md)
 
-- [Server Setup](./Server_Setup.md)
+* [Server Setup](./Server_Setup.md)
 
-- [Optional Installs](./Optional_Installs.md)
+* [Optional Installs](./Optional_Installs.md)
 
-- Terraform Deployments:
+* Terraform Deployments:
 
-    - [Ubuntu VM](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+    * [Ubuntu VM with Terraform](./tf-workspaces/ubuntu_vm/Ubuntu_VM.md) - Deploy an Ubuntu Linux Server VM.
 
-    - [Ubuntu VM K8S Single Node with MicroK8S](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy a simple Ubuntu Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+    * [Ubuntu VM K8S Single Node MicroK8S with Terraform](./tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy an Ubuntu Linux Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
 
------
+---
 
 #### GitHub Repo Information:
 
@@ -339,5 +383,4 @@ GitHub Repository: [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-se
 
 Author: Blaze Bryant [naturalblaze](https://github.com/naturalblaze)
 
------
-
+---

--- a/tf-workspaces/ubuntu_vm/Ubuntu_VM.md
+++ b/tf-workspaces/ubuntu_vm/Ubuntu_VM.md
@@ -1,143 +1,167 @@
 # Ubuntu VM with Terraform
 
+Our first Terraform workspace will be the deployment of a single Ubuntu Linux VM. This will not only test our lab setup to ensure everything is working correctly, we can also use this to easily deploy a Linux VM if we want to test something. 
+
+> :bulb: **Note:** I'm separating the Terraform configurations into separate files for the different configuration blocks to help with readability but the file structure and naming patterns are completely up to you. You can have all the configurations in the same `.tf` file if you chose. 
 
 ## Table of Contents
 
-- [Description](./Ubuntu_VM.md#description)
+* [Description](#description)
 
-- [Terraform VM Deployment](./Ubuntu_VM.md#terraform-vm-deployment)
+* [Environment](#environment)
 
+* [Terraform VM Deployment](#terraform-vm-deployment)
+
+* [Terraform Configuration Walkthrough](#terraform-configurations-walkthrough)
 
 ## Description
 
-Deploy a simple Ubuntu Server VM with Terraform to test your lab setup.
+Deploy a single Ubuntu Server VM with Terraform to our lab system.
 
 Key Aspects:
 
-- Create a KVM `storage_pool`
+* Create a KVM `storage_pool`
 
-- Download an Ubuntu server cloud image `QCOW2` disk
+* Download an Ubuntu server cloud image `QCOW2` disk
 
-- Deploy an Ubuntu server `virtual machine`
+* Deploy an Ubuntu server `virtual machine`
 
-- Configure VM with `cloud-init`
+* Configure VM with `cloud-init`
 
+## Environment
+
+To set or override any of the `variables.tf` values for your specific use just rename `terraform.tfvars.example` to `terraform.tfvars` and set the values you want for your environment.
+
+| Name | Required | Default | Description |
+| ---- | -------- | ------- | ----------- |
+| libvirt_pool_path | ✅ | /var/lib/libvirt/images/terraform/ubuntu_vm | Local path for the Libvirt storage pool to be created. |
+| img_url | ✅ | https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img | Linux URL for QCOW2 image. |
+| hostname | ✅ | ubuntu | VM hostname. |
+| packages | ✅ | qemu-guest-agent | Linux packages to install during the cloud-init configuration, `qemu-guest-agent` needed for Terraform to validate the install. |
+| cpus | ✅ | 1 | CPUs allocated to VM. |
+| memory | ✅ | 1024 | Memory allocated to VM. |
+| root_pwd | ✅ | rootplease | VM root password. |
+| username | ✅ | ubuntu | VM user to create. |
+| ssh_public_key | ✅ | ~/.ssh/id_ed25519.pub | Path to SSH Public key for user. |
+| network | ✅ | default | KVM network to use for VM network interface. (`default` or `hostbridge`) |
+| dhcp | ✅ | True | Use DHCP for VM network config. |
+| ip_address | 🚫 | None | Static IP address for VM. * |
+| subnet_cidr | 🚫 | None | CIDR Subnet mask for VM. * |
+| gateway | 🚫 | None | Default gateway IP address. * |
+| nameservers | 🚫 | None | List of DNS nameservers. * |
+> \* Only needed if DHCP is set to `False`
 
 ## Terraform VM Deployment
 
-- Clone [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-setup-ubuntu-kvm) code from GitHub
+I have all the needed configuration files setup in the Github repository and there are default values set for all the required variables so if you do not want or need to change any of the defaults you can easily just clone the repo down and deploy the initial environment. I will walk through what all the different files are doing later in the wiki.
 
-    > :warning: **Note:** This is if you setup SSH key access using [Optional Installs - GitHub Setup](../../Optional_Installs.md#github-setup), otherwise use HTTPS URL and follow the username and password prompts
+* Clone [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-setup-ubuntu-kvm) code from GitHub
 
-    ```bash
-    git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
-    ```
+```bash
+# HTTPS
+git clone https://github.com/naturalblaze/lab-setup-ubuntu-kvm.git
 
-- Change to Terraform workspace directory
+# SSH
+git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
+```
 
-    ```bash
-    cd lab-setup-ubuntu-kvm/tf-workspaces/ubuntu_vm
-    ```
+* Change to Terraform workspace directory
 
-> :exclamation: **Note:** There are default values set for all the required variables so if you do not want or need to change any of the defaults you can skip editing `terraform.tfvars.example` and renaming it to `terraform.tfvars`, just skip to the `Initialize Terraform workspace` step
+```bash
+cd lab-setup-ubuntu-kvm/tf-workspaces/ubuntu_vm
+```
 
-- Edit the variables `terraform.tfvars.example` file with the values you want for your environment
+* Initialize Terraform workspace
 
-    | Name | Required | Default | Description |
-    | ---- | -------- | ------- | ----------- |
-    | libvirt_pool_path | ✅ | /var/lib/libvirt/images/terraform | Local path for the Libvirt storage pool to be created. |
-    | ubuntu_img_url | ✅ | https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img | Linux URL for QCOW2 image. |
-    | hostname | ✅ | ubuntu | VM hostname. |
-    | packages | ✅ | qemu-guest-agent | Linux packages to install during the cloud-init configuration, `qemu-guest-agent` needed for Terraform to validate the install. |
-    | cpus | ✅ | 1 | CPUs allocated to VM. |
-    | memory | ✅ | 1024 | Memory allocated to VM. |
-    | root_pwd | ✅ | superrootpassword | VM root password. |
-    | username | ✅ | ubuntu | VM user to create. |
-    | ssh_public_key | ✅ | ~/.ssh/id_ed25519.pub | Path to SSH Public key for user. |
-    | dhcp | ✅ | True | Use DHCP for VM network config. |
-    | network | ✅ | default | KVM network to use for VM network interface. |
-    | ip_address | 🚫 | None | Static IP address for VM. Only needed if DHCP is set to False. |
-    | subnet | 🚫 | None | CIDR Subnet mask for VM. Only needed if DHCP is set to False. |
-    | gateway | 🚫 | None | Default gateway IP address. Only needed if DHCP is set to False. |
-    | nameservers | 🚫 | None | List of DNS nameservers. Only needed if DHCP is set to False. |
+```bash
+terraform init
+```
 
-- Rename `terraform.tfvars.example` file to `terraform.tfvars`
+* Format Terraform files
 
-    ```bash
-    mv terraform.tfvars.example terraform.tfvars
-    ```
+```bash
+terraform fmt
+```
 
-- Initialize Terraform workspace
+* Validate Terraform configuration
 
-    ```bash
-    terraform init
-    ```
+```bash
+terraform validate
+```
 
-- Format Terraform files
+* Plan Terraform deployment
 
-    ```bash
-    terraform fmt
-    ```
+```bash
+terraform plan
+```
 
-- Validate Terraform configuration
+> :bulb: **Note:** You can use the argument `--auto-approve` to bypass prompt for approval for apply and destroy
 
-    ```bash
-    terraform validate
-    ```
+* Deploy Terraform resources
 
-- Plan Terraform deployment
+```bash
+terraform apply
+```
 
-    ```bash
-    terraform plan
-    ```
+* Validate your deployment
 
-- Deploy Terraform resources
+```bash
+ssh <username>@<ip-address>
+```
 
-    > :exclamation: **Note:** Use argument `--auto-approve` to bypass prompt for approval
+* Destroy (delete) Terraform resources
 
-    ```bash
-    terraform apply
-    ```
+```bash
+terraform destroy
+```
 
-- Validate your deployment
+## Terraform Configurations Walkthrough
 
-    > :exclamation: **Note:** You should see the IP Address that was assigned to your VM in the output of the `terraform apply` command
+* [provider.tf](./provider.tf) - The `terraform/required_providers` and `provider` blocks is how you define and download the plugins used to interact with the cloud providers, SaaS providers, and other APIs. We are deploying to our local KVM resources using the [libvrit](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs) provider. After performing the `terraform init` in a workspace the provider plugins are downloaded and added to the workspace. More details at [Terraform Provider Block](https://developer.hashicorp.com/terraform/language/providers).
 
-    ```bash
-    ssh <username>@<ip-address>
-    ```
+* [variables.tf](./variables.tf) - Use the variable block to parameterize your configuration, making your modules dynamic, reusable, and flexible by letting them customize behavior with different values at run time. We have defaults set for all the required variables, but they can be overridden by defining them in the `terraform.tfvars` file. More details at [Terraform Variables Block](https://developer.hashicorp.com/terraform/language/block/variable).
 
-- Destroy Terraform resources
+* [terraform.tfvars](./terraform.tfvars.example) - A Terraform .tfvars file is a plain text file used to assign values to input variables declared within your Terraform configuration. These files are crucial for separating configuration details from your core infrastructure code, enabling greater flexibility and reusability, especially across different environments (e.g., development, staging, production). An example file is located at [terraform.tfvars.example](./terraform.tfvars.example) just change the filename for it to be consumed by the workspace. More details at [Terraform .tfvars file](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/guides/terraform-vars)
 
-    > :exclamation: **Note:** Use argument `--auto-approve` to bypass prompt for approval
+> :warning: If you are using a source control system like GitHub make sure you exlude your `.tfvars` files from commits or your sensitive secrets or environment details could be accessible to the public and introduce vulnerabilities.
 
-    ```bash
-    terraform destroy
-    ```
+* [main.tf](./main.tf) - The main/resource block defines a piece of infrastructure and specifies the settings for Terraform to create it with. The arguments that an individual resource supports are determined by the provider. This is where all the different resources needed for our enviornment are defined. More details at [Terraform Resource Block](https://developer.hashicorp.com/terraform/language/block/resource)
 
+* [data.tf](./data.tf) - The data block fetches data about a resource from the provider without provisioning an associated infrastructure object. You can reference data source attributes to configure other resources, keeping your configuration dynamic and preventing hardcoding. More details at [Terraform Data Block](https://developer.hashicorp.com/terraform/language/block/data)
+
+* templates - We are using this with the `templates` folder and the `.tftpl` template files so that we can render configurations with our variables injected for the cloud-init configurations of the VM. More details at [Terraform Template Files](https://developer.hashicorp.com/terraform/language/functions/templatefile)
+
+    * [cloud_init.tftpl](./templates/cloud_init.tftpl) - Cloud-init Linux system configuration: installed packages, commands to run, user and password setup, etc.
+
+    * [meta_data.tftpl](./templates/meta_data.tftpl) - Cloud-init meta-data for Linux system.
+
+    * [network_config.tftpl](./templates/network_config.tftpl) - Cloud-init network configuration for Linux system. Allows for DHCP or static network configurations.
+
+* [output.tf](./output.tf) - The output block lets you expose information about your infrastructure. We use this to show the rendered template information and display the resource IP address after deployment. More details at [Terraform Output Block](https://developer.hashicorp.com/terraform/language/block/output)
+
+---
 
 ## **🎉 Congratulations you have completed your first IaC deployment using Terraform 🎉**
 
+### [Next Project - Deploy Ubuntu VM with MicroK8S](../ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md)
 
-### [Next Lesson - Deploy Ubuntu VM with MicroK8S](../ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md)
-
------
+---
 
 ### Resources
 
 #### Repo Table of Contents:
 
-- [Home](../../README.md)
+* [Home](../../README.md)
 
-- [Server Setup](../../Server_Setup.md)
+* [Server Setup](../../Server_Setup.md)
 
-- [Optional Installs](../../Optional_Installs.md)
+* [Optional Installs](../../Optional_Installs.md)
 
-- Terraform Deployments:
+* Terraform Deployments:
 
-    - [Ubuntu VM](./Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+    * [Ubuntu VM with Terraform](./Ubuntu_VM.md) - Deploy an Ubuntu Linux Server VM.
 
-    - [Ubuntu VM K8S Single Node with MicroK8S](../ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy a simple Ubuntu Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+    * [Ubuntu VM K8S Single Node MicroK8S with Terraform](../ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md) - Deploy an Ubuntu Linux Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
 
 
 #### Directory Structure:
@@ -145,9 +169,9 @@ Key Aspects:
 ```text
 ubuntu_vm/
 ├── data.tf
+├── main.tf
 ├── output.tf
 ├── provider.tf
-├── resource.tf
 ├── templates
 │   ├── cloud_init.tftpl
 │   ├── meta_data.tftpl

--- a/tf-workspaces/ubuntu_vm/data.tf
+++ b/tf-workspaces/ubuntu_vm/data.tf
@@ -1,4 +1,5 @@
 # data: templates for cloud_init, meta_data, and network_config for vm
+
 data "template_file" "user_data" {
   template = file("${path.module}/templates/cloud_init.tftpl")
   vars = {
@@ -21,7 +22,7 @@ data "template_file" "network_config" {
   vars = {
     dhcp        = var.dhcp
     ip_address  = var.ip_address
-    subnet      = var.subnet
+    subnet      = var.subnet_cidr
     gateway     = var.gateway
     nameservers = jsonencode(var.nameservers)
   }

--- a/tf-workspaces/ubuntu_vm/main.tf
+++ b/tf-workspaces/ubuntu_vm/main.tf
@@ -1,7 +1,8 @@
-# resource: terraform resources for deployment
+# main/resource: terraform resources for deployment
+
 # Resource: for creating pool
 resource "libvirt_pool" "ubuntu" {
-  name = "ubuntu-test"
+  name = "ubuntu-vm"
   type = "dir"
   target {
     path = var.libvirt_pool_path
@@ -12,7 +13,7 @@ resource "libvirt_pool" "ubuntu" {
 resource "libvirt_volume" "ubuntu" {
   name   = "ubuntu-qcow2"
   pool   = libvirt_pool.ubuntu.name
-  source = var.ubuntu_img_url
+  source = var.img_url
   format = "qcow2"
 }
 
@@ -31,6 +32,7 @@ resource "libvirt_cloudinit_disk" "commoninit" {
 resource "libvirt_domain" "domain-ubuntu" {
   # Set VM name and resources
   name   = var.hostname
+  type   = "kvm"
   vcpu   = var.cpus
   memory = var.memory
 

--- a/tf-workspaces/ubuntu_vm/output.tf
+++ b/tf-workspaces/ubuntu_vm/output.tf
@@ -1,16 +1,24 @@
 # output: terraform output blocks
-# Uncomment for debugging what the data templates will render. WARNING this will show sensitive data
-# output "user_data" {
-#   value = "\n${data.template_file.user_data.rendered}"
-# }
-# output "network_config" {
-#   value = "\n${data.template_file.network_config.rendered}"
-# }
-# output "meta_data" {
-#   value = "\n${data.template_file.meta_data.rendered}"
-# }
 
+output "user_data" {
+  value       = "\n${data.template_file.user_data.rendered}"
+  description = "Cloud-Init packages, commands, and user data configs"
+  sensitive   = true
+}
+
+output "network_config" {
+  value       = "\n${data.template_file.network_config.rendered}"
+  description = "Cloud-Init network interface config"
+  sensitive   = false
+}
+output "meta_data" {
+  value       = "\n${data.template_file.meta_data.rendered}"
+  description = "Cloud-Init meta data config"
+  sensitive   = false
+}
 
 output "vm_ip_address" {
-  value = libvirt_domain.domain-ubuntu.network_interface.0.addresses.0
+  value       = "\nVM Login: ssh ${var.username}@${libvirt_domain.domain-ubuntu.network_interface.0.addresses.0}"
+  description = "Ubuntu VM IP address"
+  sensitive   = false
 }

--- a/tf-workspaces/ubuntu_vm/provider.tf
+++ b/tf-workspaces/ubuntu_vm/provider.tf
@@ -1,14 +1,16 @@
 # provider: terraform config and libvirt provider
+
 # Terraform provider for libvirt: https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
+      source  = "dmacvicar/libvirt"
+      version = "~> 0.8.0"
     }
   }
 }
 
-# Configure the Libvirt provider for local QEMU system
+# Configure the Libvirt provider for local QEMU system resources
 provider "libvirt" {
   uri = "qemu:///system"
 }

--- a/tf-workspaces/ubuntu_vm/templates/meta_data.tftpl
+++ b/tf-workspaces/ubuntu_vm/templates/meta_data.tftpl
@@ -1,2 +1,3 @@
+#cloud-config
 local-hostname: ${hostname}
 instance-id: ${hostname}

--- a/tf-workspaces/ubuntu_vm/templates/network_config.tftpl
+++ b/tf-workspaces/ubuntu_vm/templates/network_config.tftpl
@@ -1,3 +1,4 @@
+#cloud-config
 network:
   version: 2
   renderer: networkd

--- a/tf-workspaces/ubuntu_vm/terraform.tfvars.example
+++ b/tf-workspaces/ubuntu_vm/terraform.tfvars.example
@@ -1,6 +1,6 @@
 # Variable file for ubuntu_vm workspace
-libvirt_pool_path = "/var/lib/libvirt/images/terraform/ubuntu-test"
-ubuntu_img_url    = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+libvirt_pool_path = "/var/lib/libvirt/images/terraform/ubuntu_vm"
+img_url           = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
 hostname          = "<hostname>"
 packages          = ["qemu-guest-agent"]
 cpus              = "<number-of-cpus>"
@@ -8,9 +8,9 @@ memory            = "<amount-of-memory>"
 root_pwd          = "<root-password>"
 username          = "<username>"
 ssh_public_key    = "~/.ssh/<your-ssh-key>.pub"
-dhcp              = "<true|false>"
 network           = "<network-name>"
+dhcp              = "<true|false>"
 ip_address        = "<ip-address>"
-subnet            = "<subnet-cidr>"
+subnet_cidr       = "<subnet-cidr>"
 gateway           = "<gateway-ip>"
 nameservers       = ["<dns-server1>", "<dns-server2>"]

--- a/tf-workspaces/ubuntu_vm/variables.tf
+++ b/tf-workspaces/ubuntu_vm/variables.tf
@@ -1,11 +1,12 @@
-# variable: Variables for ubuntu_vm module
+# variable: Variables for ubuntu_vm workspace
+
 variable "libvirt_pool_path" {
   description = "local path for libvirt storage pool"
   type        = string
-  default     = "/var/lib/libvirt/images/terraform"
+  default     = "/var/lib/libvirt/images/terraform/ubuntu_vm"
 }
 
-variable "ubuntu_img_url" {
+variable "img_url" {
   description = "linux url for qcow2 image"
   type        = string
   default     = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
@@ -38,7 +39,7 @@ variable "memory" {
 variable "root_pwd" {
   description = "vm root password"
   type        = string
-  default     = "superrootpassword"
+  default     = "rootplease"
   sensitive   = true
 }
 
@@ -55,16 +56,17 @@ variable "ssh_public_key" {
   sensitive   = true
 }
 
-variable "dhcp" {
-  description = "use dhcp for network"
-  type        = string
-  default     = "true"
-}
-
 variable "network" {
   description = "kvm network"
   type        = string
   default     = "default"
+}
+
+# Network settings for the VM if DHCP is true then the 4 below are not needed
+variable "dhcp" {
+  description = "use dhcp for network"
+  type        = string
+  default     = "true"
 }
 
 variable "ip_address" {
@@ -73,7 +75,7 @@ variable "ip_address" {
   default     = ""
 }
 
-variable "subnet" {
+variable "subnet_cidr" {
   description = "subnet mask (cidr)"
   type        = string
   default     = ""

--- a/tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md
+++ b/tf-workspaces/ubuntu_vm_microk8s/Ubuntu_VM_MicroK8S.md
@@ -1,235 +1,261 @@
-# Ubuntu VM K8S Single Node with MicroK8S
+# Ubuntu VM K8S Single Node MicroK8S with Terraform
 
+Our next Terraform workspace will be the deployment of a single Ubuntu Linux VM and then installing and configuring MicroK8S (Kubernetes). Rarely do you only need to deploy a vanilla Linux system so lets expand and add some features to our deployment.
+
+> :bulb: **Note:** I'm separating the Terraform configurations into separate files for the different configuration blocks to help with readability but the file structure and naming patterns are completely up to you. You can have all the configurations in the same `.tf` file if you chose. 
 
 ## Table of Contents
 
-- [Description](./Ubuntu_VM_MicroK8S.md#description)
+* [Description](#description)
 
-    - [Key Aspects](./Ubuntu_VM_MicroK8S.md#key-aspects)
+* [Environment](#environment)
 
-- [Terraform VM Deployment](./Ubuntu_VM_MicroK8S.md#terraform-vm-deployment)
+* [Terraform VM Deployment](#terraform-vm-deployment)
 
-- [Ansible Install and Deployment](./Ubuntu_VM_MicroK8S.md#ansible-install-and-deployment)
+* [Terraform Configuration Walkthrough](#terraform-configurations-walkthrough)
 
-    - [Ansible Setup](./Ubuntu_VM_MicroK8S.md#ansible-setup)
+* [Ansible Deployment](#ansible-deployment)
 
-    - [Ansible Testing](./Ubuntu_VM_MicroK8S.md#ansible-testing)
+    * [Ansible Testing](#ansible-testing)
 
-    - [Install MicroK8S](./Ubuntu_VM_MicroK8S.md#install-microk8s)
+    * [Install MicroK8S](nstall-microk8s)
 
-    - [Deploy Nginx Container](./Ubuntu_VM_MicroK8S.md#deploy-nginx-container)
+    * [Deploy Nginx Container](#deploy-nginx-container)
 
-- [Delete Terraform Resources](./Ubuntu_VM_MicroK8S.md#delete-terraform-resources)
-
+* [Delete Terraform Resources](#delete-terraform-resources)
 
 ## Description
 
+Deploy a single Ubuntu Server VM with Terraform to our lab system and configure Kubernetes MicroK8S single node enviornment.
 Now that we have deployed a simple Ubuntu Server VM that is not much fun, so lets expand on that and make something more usable. We will add some additional steps to the deployment to expand the `QCOW2` disk (since it only provisioned with a very small filesystem) and use `Ansible` to install and configure Kubernetes MicroK8S along with a sample `NGINX` application.
 
+Key Aspects:
 
-### Key Aspects
+* Create a KVM `storage_pool`
 
-- Create a KVM `storage_pool`
+* Download an Ubuntu server cloud image `QCOW2` disk
 
-- Download an Ubuntu server cloud image `QCOW2` disk
+* Expand the `QCOW2` disk to add some additional storage to the system (ex. 20G)
 
-- Expand the `QCOW2` disk to add some additional storage to the system (ex. 20G)
+* Deploy an Ubuntu server `virtual machine`
 
-- Deploy an Ubuntu server `virtual machine`
+* Configure VM with `cloud-init`
 
-- Configure VM with `cloud-init`
+* Ansible Configs:
 
-- Using Ansible:
+  > :bulb: **Note:** I'm using Ansible for the install and configuration `microk8s`. You could do this via `cloud-init` and/or `remote-exec` but Terraform is not very good doing configurations on servers (or at least validating the install status) and waiting for apps to be fully available
 
-  > :exclamation: **Note:** I'm using Ansible for the install and configuration `microk8s`. You could do this via `cloud-init` and/or `remote-exec` but Terraform is not very good doing configurations on servers and waiting for apps to be fully available
+  * Install Kubernetes and configure single node cluster with `microk8s snap`
 
-  - Install Kubernetes and configure single node cluster with `microk8s snap`
+  * Enable MicroK8S addons: `dns hostpath-storage dashboard helm3`
 
-  - Enable MicroK8S addons: `dns hostpath-storage dashboard helm3`
+  * Deploy a K8S service for microk8s dashboard to make it accessible via the host IP address
 
-  - Deploy a K8S service for microk8s dashboard to make it accessible via the host IP address
+  * Deploy a NGINX container with a LoadBalancer service
 
-  - Deploy a NGINX container with a LoadBalancer service
+## Environment
 
+To set or override any of the `variables.tf` values for your specific use just rename `terraform.tfvars.example` to `terraform.tfvars` and set the values you want for your environment.
+
+| Name | Required | Default | Description |
+| ---- | -------- | ------- | ----------- |
+| local_root_pwd | ✅/🚫 | None | Only required if your lab server requires a user password for sudo commands. |
+| libvirt_pool_path | ✅ | /var/lib/libvirt/images/terraform/ubuntu_microk8s | Local path for the Libvirt storage pool to be created. |
+| img_url | ✅ | https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img | Linux URL for QCOW2 image. |
+| hostname | ✅ | ubuntu | VM hostname. |
+| packages | ✅ | qemu-guest-agent | Linux packages to install during the cloud-init configuration, `qemu-guest-agent` needed for Terraform to validate the install. |
+| cpus | ✅ | 2 | CPUs allocated to VM. |
+| memory | ✅ | 2048 | Memory allocated to VM (in MB). |
+| disk_size | ✅ | 20 | Capacity to add to `qcow2` disk (in GB). |
+| root_pwd | ✅ | superrootpassword | VM root password. |
+| username | ✅ | ubuntu | VM user to create. |
+| ssh_public_key | ✅ | ~/.ssh/id_ed25519.pub | Path to SSH Public key for user. |
+| ssh_private_key | ✅ | ~/.ssh/id_ed25519 | Path to SSH Private key for user. |
+| network | ✅ | default | KVM network to use for VM network interface. (`default` or `hostbridge`) |
+| dhcp | ✅ | True | Use DHCP for VM network config. |
+| ip_address | 🚫 | None | Static IP address for VM. * |
+| subnet_cidr | 🚫 | None | CIDR Subnet mask for VM. * |
+| gateway | 🚫 | None | Default gateway IP address. * |
+| nameservers | 🚫 | None | List of DNS nameservers. * |
+> \* Only needed if DHCP is set to `False`
 
 ## Terraform VM Deployment
 
-- Clone [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-setup-ubuntu-kvm) code from GitHub
+I have all the needed configuration files setup in the Github repository and there are default values set for all the required variables so if you do not want or need to change any of the defaults you can easily just clone the repo down and deploy the initial environment. I will walk through what all the different files are doing later in the wiki.
 
-    > :warning: **Note:** This is if you setup SSH key access using [Optional Installs - GitHub Setup](../../Optional_Installs.md#github-setup), otherwise use HTTPS URL and follow the username and password prompts
+* Clone [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-setup-ubuntu-kvm) code from GitHub
 
-    ```bash
-    git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
-    ```
+```bash
+# HTTPS
+git clone https://github.com/naturalblaze/lab-setup-ubuntu-kvm.git
 
-- Change to Terraform workspace directory
-
-    ```bash
-    cd lab-setup-ubuntu-kvm/tf-workspaces/ubuntu_vm_microk8s
-    ```
-
-> :exclamation: **Note:** There are default values set for all the required variables so if you do not want/need to change any of the defaults you can skip editing `terraform.tfvars.example` and renaming it to `terraform.tfvars`.
-
-> :warning: You only need to change and uncomment `local_root_pwd` if you lab server requires a password for sudo privileges, uncomment the `local_root_pwd` in `variables.tf`, and adjust the command in `resource.tf`
-
-- Edit the variables `terraform.tfvars.example` file with the values you want for your environment
-
-    | Name | Required | Default | Description |
-    | ---- | -------- | ------- | ----------- |
-    | local_root_pwd | ✅ or 🚫 | None | This is only required if your lab server requires a user password for sudo commands. |
-    | libvirt_pool_path | ✅ | /var/lib/libvirt/images/terraform | Local path for the Libvirt storage pool to be created. |
-    | ubuntu_img_url | ✅ | https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img | Linux URL for QCOW2 image. |
-    | hostname | ✅ | ubuntu | VM hostname. |
-    | packages | ✅ | qemu-guest-agent | Linux packages to install during the cloud-init configuration, `qemu-guest-agent` needed for Terraform to validate the install. |
-    | cpus | ✅ | 2 | CPUs allocated to VM. |
-    | memory | ✅ | 2048 | Memory allocated to VM (in MB). |
-    | disk_size | ✅ | 20 | Capacity to add to `qcow2` disk (in GB). |
-    | root_pwd | ✅ | superrootpassword | VM root password. |
-    | username | ✅ | ubuntu | VM user to create. |
-    | ssh_public_key | ✅ | ~/.ssh/id_ed25519.pub | Path to SSH Public key to use for user on lab server. |
-    | dhcp | ✅ | True | Use DHCP for VM network config. |
-    | network | ✅ | default | KVM network to use for VM network interface. |
-    | ip_address | 🚫 | None | Static IP address for VM. Only needed if DHCP is set to False. |
-    | subnet | 🚫 | None | CIDR Subnet mask for VM. Only needed if DHCP is set to False. |
-    | gateway | 🚫 | None | Default gateway IP address. Only needed if DHCP is set to False. |
-    | nameservers | 🚫 | None | List of DNS nameservers. Only needed if DHCP is set to False. |
-
-- Rename `terraform.tfvars.example` file to `terraform.tfvars`
-
-    ```bash
-    mv terraform.tfvars.example terraform.tfvars
-    ```
-
-- Initialize Terraform workspace
-
-    ```bash
-    terraform init
-    ```
-
-- Format Terraform files
-
-    ```bash
-    terraform fmt
-    ```
-
-- Validate Terraform configuration
-
-    ```bash
-    terraform validate
-    ```
-
-- Plan Terraform deployment
-
-    ```bash
-    terraform plan
-    ```
-
-- Deploy Terraform resources
-
-    > :exclamation: **Note:** Use argument `--auto-approve` to bypass prompt for approval
-
-    ```bash
-    terraform apply
-    ```
-
-- Validate your deployment
-
-    > :exclamation: **Note:** You should see the IP Address that was assigned to your VM in the output of the `terraform apply` command
-
-    ```bash
-    ssh <username>@<ip-address>
-    ```
+# SSH
+git clone git@github.com:naturalblaze/lab-setup-ubuntu-kvm.git
+```
 
 
-## Ansible Install and Deployment
+* Change to Terraform workspace directory
 
-### Ansible Setup
+```bash
+cd lab-setup-ubuntu-kvm/tf-workspaces/ubuntu_vm_microk8s
+```
 
-Follow the installation instructions in [Optional Installs - Ansible Install](../../Optional_Installs.md#ansible-install) to install ansible on the lab server if you haven't already done so.
+* Initialize Terraform workspace
+
+```bash
+terraform init
+```
+
+* Format Terraform files
+
+```bash
+terraform fmt
+```
+
+* Validate Terraform configuration
+
+```bash
+terraform validate
+```
+
+* Plan Terraform deployment
+
+```bash
+terraform plan
+```
+
+> :bulb: **Note:** You can use the argument `--auto-approve` to bypass prompt for approval for apply and destroy
+
+* Deploy Terraform resources
+
+```bash
+terraform apply
+```
+
+* Validate your deployment
+
+```bash
+ssh <username>@<ip-address>
+```
+
+* Destroy (delete) Terraform resources
+
+```bash
+terraform destroy
+```
+
+## Terraform Configurations Walkthrough
+
+* [provider.tf](./provider.tf) - The `terraform/required_providers` and `provider` blocks is how you define and download the plugins used to interact with the cloud providers, SaaS providers, and other APIs. We are deploying to our local KVM resources using the [libvrit](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs) provider. After performing the `terraform init` in a workspace the provider plugins are downloaded and added to the workspace. More details at [Terraform Provider Block](https://developer.hashicorp.com/terraform/language/providers).
+
+* [variables.tf](./variables.tf) - Use the variable block to parameterize your configuration, making your modules dynamic, reusable, and flexible by letting them customize behavior with different values at run time. We have defaults set for all the required variables, but they can be overridden by defining them in the `terraform.tfvars` file. More details at [Terraform Variables Block](https://developer.hashicorp.com/terraform/language/block/variable).
+
+* [terraform.tfvars](./terraform.tfvars.example) - A Terraform .tfvars file is a plain text file used to assign values to input variables declared within your Terraform configuration. These files are crucial for separating configuration details from your core infrastructure code, enabling greater flexibility and reusability, especially across different environments (e.g., development, staging, production). An example file is located at [terraform.tfvars.example](./terraform.tfvars.example) just change the filename for it to be consumed by the workspace. More details at [Terraform .tfvars file](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/guides/terraform-vars)
+
+> :warning: If you are using a source control system like GitHub make sure you exlude your `.tfvars` files from commits or your sensitive secrets or environment details could be accessible to the public and introduce vulnerabilities.
+
+* [main.tf](./main.tf) - The main/resource block defines a piece of infrastructure and specifies the settings for Terraform to create it with. The arguments that an individual resource supports are determined by the provider. This is where all the different resources needed for our enviornment are defined. More details at [Terraform Resource Block](https://developer.hashicorp.com/terraform/language/block/resource)
+
+* [data.tf](./data.tf) - The data block fetches data about a resource from the provider without provisioning an associated infrastructure object. You can reference data source attributes to configure other resources, keeping your configuration dynamic and preventing hardcoding. More details at [Terraform Data Block](https://developer.hashicorp.com/terraform/language/block/data)
+
+* templates - We are using this with the `templates` folder and the `.tftpl` template files so that we can render configurations with our variables injected for the cloud-init configurations of the VM. More details at [Terraform Template Files](https://developer.hashicorp.com/terraform/language/functions/templatefile)
+
+    * [cloud_init.tftpl](./templates/cloud_init.tftpl) - Cloud-init Linux system configuration: installed packages, commands to run, user and password setup, etc.
+
+    * [meta_data.tftpl](./templates/meta_data.tftpl) - Cloud-init meta-data for Linux system.
+
+    * [network_config.tftpl](./templates/network_config.tftpl) - Cloud-init network configuration for Linux system. Allows for DHCP or static network configurations.
+
+* [output.tf](./output.tf) - The output block lets you expose information about your infrastructure. We use this to show the rendered template information and display the resource IP address after deployment. More details at [Terraform Output Block](https://developer.hashicorp.com/terraform/language/block/output)
+
+## Ansible Deployment
+
+[Ansible Install](../../Optional_Installs.md#ansible-install)
 
 ### Ansible Testing
 
 Part of the Terraform VM deployment created an `ansible.cfg` file with some needed configurations to connect to the VM and an inventory file `ansible/inventory.ini` for the playbooks to use.
 
-- Test connecting to the VM with the `ping` module
+* Test connecting to the VM with the `ping` module
 
-    ```bash
-    ansible-playbook -i ansible/inventory.ini ansible/ping.yaml
-    ```
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/ping.yaml
+```
 
 ### Install MicroK8S
 
-- Install and configure `microk8s`
+* Install and configure `microk8s`
 
-    ```bash
-    ansible-playbook -i ansible/inventory.ini ansible/microk8s_install.yaml
-    ```
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/microk8s_install.yaml
+```
 
-    > :exclamation: **Note:** One of the addons we enabled was `dashboard` which allows for a WebUI to view the status of our K8S cluster. The URL and Token to connect to the WebUI are printed in the debug task at the end of the playbook
+> :bulb: **Note:** One of the addons we enabled was `dashboard` which allows for a WebUI to view the status of our K8S cluster. The URL and Token to connect to the WebUI are printed in the debug task at the end of the playbook
 
-- Validate microk8s install
+* Validate microk8s install
 
-    ```bash
-    ssh <username>@<ip-address>
-    microk8s version
-    microk8s status --wait-ready
-    kubectl version
-    kubectl get nodes
-    ```
+```bash
+ssh <username>@<ip-address>
+microk8s version
+microk8s status --wait-ready
+kubectl version
+kubectl get nodes
+```
 
 ### Deploy Nginx Container
 
 Now we have a fully functional `microk8s` install let's deploy a simple NGINX application with an `LoadBalancer` service to expose the app to the `8080` port of the lab server
 
-- Deploy `nginx` container with `LoadBalancer` service
+* Deploy `nginx` container with `LoadBalancer` service
 
-    ```bash
-    ansible-playbook -i ansible/inventory.ini ansible/nginx_install.yaml
-    ```
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/nginx_install.yaml
+```
 
-- Validate NGINX install: `https://<server-ip>:8080`
+* Validate NGINX install: `https://<server-ip>:8080`
 
-    > :exclamation: **Note:** The `nginx_install.yaml` playbook creates a new namespace in our K8S instance named `nginx-test`
+> :exclamation: **Note:** The `nginx_install.yaml` playbook creates a new namespace in our K8S instance named `nginx-test`
 
-    ```bash
-    ssh <username>@<ip-address>
-    kubectl get pods --namespace=nginx-test
-    kubectl get services --namespace=nginx-test
-    ```
+```bash
+ssh <username>@<ip-address>
+kubectl get pods --namespace=nginx-test
+kubectl get services --namespace=nginx-test
+```
 
 
 ## Delete Terraform Resources
 
-- Destroy Terraform resources
+* Destroy Terraform resources
 
-    > :exclamation: **Note:** Use argument `--auto-approve` to bypass prompt for approval
+> :bulb: **Note:** Use argument `--auto-approve` to bypass prompt for approval
 
-    ```bash
-    terraform destroy
-    ```
+```bash
+terraform destroy
+```
 
-## **🎉 Congratulations you have deployed a VM using Terraform, installed and configured Ansible on your lab server, deployed and configured MicroK8S on your VM, and installed a NGINX container and service using Ansible 🎉**
+## **🎉 Congratulations you have deployed a VM using Terraform, installed and configured Ansible on your lab server, deployed and configured MicroK8S on your VM, and deployed a NGINX container and service using Ansible 🎉**
 
 
 ### [Next Lesson - Coming Soon]()
 
------
+---
 
 ### Resources
 
 #### Repo Table of Contents:
 
-- [Home](../../README.md)
+* [Home](../../README.md)
 
-- [Server Setup](../../Server_Setup.md)
+* [Server Setup](../../Server_Setup.md)
 
-- [Optional Installs](../../Optional_Installs.md)
+* [Optional Installs](../../Optional_Installs.md)
 
-- Terraform Deployments:
+* Terraform Deployments:
 
-    - [Ubuntu VM](../ubuntu_vm/Ubuntu_VM.md) - Deploy a simple Ubuntu Server VM to test your lab setup.
+    * [Ubuntu VM with Terraform](../ubuntu_vm/Ubuntu_VM.md) - Deploy an Ubuntu Linux Server VM.
 
-    - [Ubuntu VM K8S Single Node with MicroK8S](./Ubuntu_VM_MicroK8S.md) - Deploy a simple Ubuntu Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+    * [Ubuntu VM K8S Single Node MicroK8S with Terraform](./Ubuntu_VM_MicroK8S.md) - Deploy an Ubuntu Linux Server VM, install and configure MicroK8S, and deploy your first K8S app with Ansible.
+
 
 
 #### Directory Structure:
@@ -237,26 +263,25 @@ Now we have a fully functional `microk8s` install let's deploy a simple NGINX ap
 ```text
 ubuntu_vm_microk8s/
 ├── ansible
+│   ├── inventory.ini
 │   ├── microk8s_install.yaml
 │   ├── nginx_install.yaml
 │   └── ping.yaml
+├── ansible.cfg
 ├── data.tf
+├── main.tf
 ├── output.tf
 ├── provider.tf
-├── resource.tf
 ├── templates
 │   ├── cloud_init.tftpl
 │   ├── meta_data.tftpl
 │   └── network_config.tftpl
-├── terraform.tfstate
-├── terraform.tfstate.backup
-├── terraform.tfvars
 ├── terraform.tfvars.example
 ├── Ubuntu_VM_MicroK8S.md
 └── variables.tf
 ```
 
------
+---
 
 #### GitHub Repo Information:
 
@@ -264,4 +289,4 @@ GitHub Repository: [lab-setup-ubuntu-kvm](https://github.com/naturalblaze/lab-se
 
 Author: Blaze Bryant [naturalblaze](https://github.com/naturalblaze)
 
------
+---

--- a/tf-workspaces/ubuntu_vm_microk8s/ansible.cfg
+++ b/tf-workspaces/ubuntu_vm_microk8s/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+host_key_checking = "False"
+ansible_port = "22"
+ansible_user = "nb"
+ansible_ssh_private_key_file = "~/.ssh/id_ed25519"
+ansible_python_interpreter = "/usr/bin/python3"
+ansible_ssh_common_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+stdout_callback = "debug"

--- a/tf-workspaces/ubuntu_vm_microk8s/ansible/inventory.ini
+++ b/tf-workspaces/ubuntu_vm_microk8s/ansible/inventory.ini
@@ -1,0 +1,5 @@
+[microk8s]
+192.168.10.101
+[microk8s:vars]
+ansible_user = "nb"
+microk8s_config_path="/var/snap/microk8s/current/credentials/client.config"

--- a/tf-workspaces/ubuntu_vm_microk8s/data.tf
+++ b/tf-workspaces/ubuntu_vm_microk8s/data.tf
@@ -1,4 +1,5 @@
 # data: templates for cloud_init, meta_data, and network_config for vm
+
 data "template_file" "user_data" {
   template = file("${path.module}/templates/cloud_init.tftpl")
   vars = {
@@ -23,7 +24,7 @@ data "template_file" "network_config" {
   vars = {
     dhcp        = var.dhcp
     ip_address  = var.ip_address
-    subnet      = var.subnet
+    subnet      = var.subnet_cidr
     gateway     = var.gateway
     nameservers = jsonencode(var.nameservers)
   }

--- a/tf-workspaces/ubuntu_vm_microk8s/output.tf
+++ b/tf-workspaces/ubuntu_vm_microk8s/output.tf
@@ -1,14 +1,24 @@
-# Uncomment for debugging what the data templates will render. WARNING this will show sensitive data
-# output "user_data" {
-#   value = "\n${data.template_file.user_data.rendered}"
-# }
-# output "network_config" {
-#   value = "\n${data.template_file.network_config.rendered}"
-# }
-# output "meta_data" {
-#   value = "\n${data.template_file.meta_data.rendered}"
-# }
+# output: terraform output blocks
+
+output "user_data" {
+  value       = "\n${data.template_file.user_data.rendered}"
+  description = "Cloud-Init packages, commands, and user data configs"
+  sensitive   = true
+}
+
+output "network_config" {
+  value       = "\n${data.template_file.network_config.rendered}"
+  description = "Cloud-Init network interface config"
+  sensitive   = false
+}
+output "meta_data" {
+  value       = "\n${data.template_file.meta_data.rendered}"
+  description = "Cloud-Init meta data config"
+  sensitive   = false
+}
 
 output "vm_ip_address" {
-  value = libvirt_domain.domain-ubuntu.network_interface.0.addresses.0
+  value       = "\nVM Login: ssh ${var.username}@${libvirt_domain.domain-microk8s.network_interface.0.addresses.0}"
+  description = "Ubuntu VM IP address"
+  sensitive   = false
 }

--- a/tf-workspaces/ubuntu_vm_microk8s/provider.tf
+++ b/tf-workspaces/ubuntu_vm_microk8s/provider.tf
@@ -1,9 +1,11 @@
 # provider: terraform config and libvirt provider
+
 # Terraform provider for libvirt: https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
+      source  = "dmacvicar/libvirt"
+      version = "~> 0.8.0"
     }
   }
 }

--- a/tf-workspaces/ubuntu_vm_microk8s/templates/meta_data.tftpl
+++ b/tf-workspaces/ubuntu_vm_microk8s/templates/meta_data.tftpl
@@ -1,2 +1,3 @@
+#cloud-config
 local-hostname: ${hostname}
 instance-id: ${hostname}

--- a/tf-workspaces/ubuntu_vm_microk8s/templates/network_config.tftpl
+++ b/tf-workspaces/ubuntu_vm_microk8s/templates/network_config.tftpl
@@ -1,3 +1,4 @@
+#cloud-config
 network:
   version: 2
   renderer: networkd

--- a/tf-workspaces/ubuntu_vm_microk8s/terraform.tfvars.example
+++ b/tf-workspaces/ubuntu_vm_microk8s/terraform.tfvars.example
@@ -1,7 +1,7 @@
-# Variable file for ubuntu_vm workspace
-# local_root_pwd    = "<local-user-password-for-sudo>"  # Uncomment if you lab server user requires a password for sudo commands
-libvirt_pool_path = "/var/lib/libvirt/images/terraform/ubuntu-microk8s"
-ubuntu_img_url    = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+# Variable file for ubuntu_vm_microk8s workspace
+local_root_pwd    = "<local-user-password-for-sudo>"  # Set if you lab server user requires a password for sudo commands
+libvirt_pool_path = "/var/lib/libvirt/images/terraform/ubuntu_microk8s"
+img_url           = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
 hostname          = "<hostname>"
 packages          = ["qemu-guest-agent"]
 cpus              = "<number-of-cpus>"
@@ -11,9 +11,9 @@ root_pwd          = "<root-password>"
 username          = "<username>"
 ssh_public_key    = "~/.ssh/<your-ssh-key>.pub"
 ssh_private_key   = "~/.ssh/<your-ssh-key>"
-dhcp              = "<true|false>"
 network           = "<network-name>"
+dhcp              = "<true|false>"
 ip_address        = "<ip-address>"
-subnet            = "<subnet-cidr>"
+subnet_cidr       = "<subnet-cidr>"
 gateway           = "<gateway-ip>"
 nameservers       = ["<dns-server1>", "<dns-server2>"]

--- a/tf-workspaces/ubuntu_vm_microk8s/variables.tf
+++ b/tf-workspaces/ubuntu_vm_microk8s/variables.tf
@@ -1,19 +1,19 @@
 # variable: Variables for ubuntu_vm module
-# Uncomment if you lab server user requires a password for sudo commands
-# variable "local_root_pwd" {
-#   description = "local host root password if sudo requires password"
-#   type        = string
-#   default     = ""
-#   sensitive   = true
-# }
+
+variable "local_root_pwd" {
+  description = "local host root password if sudo requires password"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
 
 variable "libvirt_pool_path" {
   description = "local path for libvirt storage pool"
   type        = string
-  default     = "/var/lib/libvirt/images/terraform"
+  default     = "/var/lib/libvirt/images/terraform/ubuntu_microk8s"
 }
 
-variable "ubuntu_img_url" {
+variable "img_url" {
   description = "linux url for qcow2 image"
   type        = string
   default     = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
@@ -22,7 +22,7 @@ variable "ubuntu_img_url" {
 variable "hostname" {
   description = "vm hostname"
   type        = string
-  default     = "ubuntu"
+  default     = "microk8s"
 }
 
 variable "packages" {
@@ -52,7 +52,7 @@ variable "disk_size" {
 variable "root_pwd" {
   description = "vm root password"
   type        = string
-  default     = "superrootpassword"
+  default     = "rootplease"
   sensitive   = true
 }
 
@@ -76,16 +76,16 @@ variable "ssh_private_key" {
   sensitive   = true
 }
 
-variable "dhcp" {
-  description = "use dhcp for network"
-  type        = string
-  default     = "true"
-}
-
 variable "network" {
   description = "kvm network"
   type        = string
   default     = "default"
+}
+
+variable "dhcp" {
+  description = "use dhcp for network"
+  type        = string
+  default     = "true"
 }
 
 variable "ip_address" {
@@ -94,7 +94,7 @@ variable "ip_address" {
   default     = ""
 }
 
-variable "subnet" {
+variable "subnet_cidr" {
   description = "subnet mask (cidr)"
   type        = string
   default     = ""


### PR DESCRIPTION
Bugfix for Terraform Libvirt 0.9.0
- README.md, Server_Setup.md, Optional_Installs.md: documentation updates
- provider.tf: locked dmacvicar/libvirt to version 0.8 as 0.9 brakes terraform configs
- main.tf: changed resource.tf files to main.tf for naming consistency
- ubuntu_vm workspace: updated documentation and terraform files
- ubuntu_vm_microk8s workspace: updated documentation and terraform files
- README.md: base update path